### PR TITLE
Feature parts logging

### DIFF
--- a/mule/parts/actuator.py
+++ b/mule/parts/actuator.py
@@ -103,6 +103,9 @@ class SteeringController(BasePart):
         pulse = self._steering_signal2pulse(self.STRAIGHT_SIGNAL)
         self.controller.set_pulse(pulse)
 
+    @property
+    def _class_string(self):
+        return "{} with {} {} left/right PWM".format(self.__class__.__name__, self.FULL_LEFT_SIGNAL,self.FULL_RIGHT_SIGNAL)
 
 
 class ThrottleController(BasePart):
@@ -113,12 +116,12 @@ class ThrottleController(BasePart):
 
     FULL_REVERSE_SIGNAL = -1
     FULL_FORWARD_SIGNAL =  1
-    STOP_SIGNAL = 0
+    NEUTRAL_SIGNAL = 0
 
     def __init__(self, controller=MockController(),
                        full_reverse_pulse=290,
                        full_forward_pulse=490,
-                       stop_pulse=390):
+                       neutral_pulse=390):
         ''' Acquires reference to controller and full forward and reverse as well 
             as pulse frequencies that are discovered during callibration 
 
@@ -128,26 +131,26 @@ class ThrottleController(BasePart):
         self.controller = controller
 
         self._reverse_signal2pulse = functools.partial(_signal2pulse, self.FULL_REVERSE_SIGNAL,
-                                                                      self.STOP_SIGNAL,
+                                                                      self.NEUTRAL_SIGNAL,
                                                                       full_reverse_pulse,
-                                                                      stop_pulse)
+                                                                      neutral_pulse)
 
-        self._forward_signal2pulse = functools.partial(_signal2pulse, self.STOP_SIGNAL,
+        self._forward_signal2pulse = functools.partial(_signal2pulse, self.NEUTRAL_SIGNAL,
                                                                       self.FULL_FORWARD_SIGNAL,
-                                                                      stop_pulse,
+                                                                      neutral_pulse,
                                                                       full_forward_pulse)
 
 
     def start(self):
         ''' Callibrate by sending stop signal '''
-        pulse = self._reverse_signal2pulse(self.STOP_SIGNAL)
+        pulse = self._reverse_signal2pulse(self.NEUTRAL_SIGNAL)
         self.controller.set_pulse(pulse)
         time.sleep(0.5)
 
 
     def transform(self, state):
         ''' Send signal as pulse to servo '''
-        if state['throttle_signal'] > self.STOP_SIGNAL:
+        if state['throttle_signal'] > self.NEUTRAL_SIGNAL:
             pulse = self._forward_signal2pulse(state['throttle_signal'])
         else:
             pulse = self._reverse_signal2pulse(state['throttle_signal'])
@@ -157,5 +160,11 @@ class ThrottleController(BasePart):
 
     def stop(self):
         ''' Signal to stop vehicle ''' 
-        pulse = self._reverse_signal2pulse(self.STOP_SIGNAL)
+        pulse = self._reverse_signal2pulse(self.NEUTRAL_SIGNAL)
         self.controller.set_pulse(pulse)
+        
+    @property
+    def _class_string(self):
+        return "{} with {} {} left/right PWM".format(self.__class__.__name__, self.FULL_LEFT_SIGNAL,self.FULL_RIGHT_SIGNAL)
+
+        

--- a/mule/parts/ai.py
+++ b/mule/parts/ai.py
@@ -51,3 +51,9 @@ class AIController(BasePart):
 
     def stop(self):
         pass
+    
+    @property
+    def _class_string(self):
+        return "{} from {}".format(self.__class__.__name__, self.model_path)
+
+    

--- a/mule/parts/base.py
+++ b/mule/parts/base.py
@@ -30,6 +30,17 @@ class BasePart(abc.ABC):
         pass
 
 
+class PartIntrospect:
+    def __str__(self):
+        return "{} with {} and {} input/output keys".format(self._class_string, self.__class__.input_keys, self.__class__.input_keys)
+
+    def __repr__(self):
+        return "{} with {} and {} input/output keys".format(self.__class__.__name__, self.__class__.input_keys, self.__class__.input_keys)
+    
+    @property
+    def _class_string(self):
+        return self.__class__.__name__
+
 class ThreadComponent:
     ''' Component held by part that added threading capability
 

--- a/mule/parts/base.py
+++ b/mule/parts/base.py
@@ -35,6 +35,7 @@ class BasePart(abc.ABC):
     def __repr__(self):
         return "{} with {} and {} input/output keys".format(self.__class__.__name__, self.__class__.input_keys, self.__class__.input_keys)
     
+    
     @property
     def _class_string(self):
         return self.__class__.__name__

--- a/mule/parts/base.py
+++ b/mule/parts/base.py
@@ -29,8 +29,6 @@ class BasePart(abc.ABC):
         ''' Stops part components '''
         pass
 
-
-class PartIntrospect:
     def __str__(self):
         return "{} with {} and {} input/output keys".format(self._class_string, self.__class__.input_keys, self.__class__.input_keys)
 

--- a/mule/parts/camera.py
+++ b/mule/parts/camera.py
@@ -1,7 +1,7 @@
 import cv2
 import numpy as np
 import time
-from parts.base import BasePart, ThreadComponent
+from parts.base import BasePart, ThreadComponent, PartIntrospect
 
 
 
@@ -138,7 +138,7 @@ class PiCam(BaseCam):
 # TODO: add device search -- on the pi, there is the possibility for multiple devices
 #                            but for one webcam, it will be 0 (I think).
 #                            if not, then >> ls -l /dev/video*
-class WebCam(BaseCam):
+class WebCam(BaseCam,PartIntrospect):
     ''' Web camera 
     
         Most web cameras are not so flexible as to allow for arbitrary

--- a/mule/parts/camera.py
+++ b/mule/parts/camera.py
@@ -1,7 +1,7 @@
 import cv2
 import numpy as np
 import time
-from parts.base import BasePart, ThreadComponent, PartIntrospect
+from parts.base import BasePart, ThreadComponent
 
 
 
@@ -64,9 +64,7 @@ class BaseCam(BasePart):
     def _update(self, **kwargs):
         ''' Updates part state '''
         pass
-
-
-
+    
 
 # TODO: impore framerate using Regulator class
 # TODO: allow for changing color inn stream of images
@@ -138,7 +136,7 @@ class PiCam(BaseCam):
 # TODO: add device search -- on the pi, there is the possibility for multiple devices
 #                            but for one webcam, it will be 0 (I think).
 #                            if not, then >> ls -l /dev/video*
-class WebCam(BaseCam,PartIntrospect):
+class WebCam(BaseCam):
     ''' Web camera 
     
         Most web cameras are not so flexible as to allow for arbitrary
@@ -187,3 +185,7 @@ class WebCam(BaseCam,PartIntrospect):
 
         return image[padding_height:image.shape[0]-padding_height, 
                      padding_width:image.shape[1]-padding_width]
+
+    @property
+    def _class_string(self):
+        return "{} {}".format(self.__class__.__name__, self.resolution)

--- a/mule/parts/camera.py
+++ b/mule/parts/camera.py
@@ -130,6 +130,9 @@ class PiCam(BaseCam):
         self.frame = next(self.stream).array
         self.rgb_stream.seek(0)
 
+    @property
+    def _class_string(self):
+        return "{} {}".format(self.__class__.__name__, self.resolution)
 
 
 # TODO: impose framerate
@@ -188,4 +191,4 @@ class WebCam(BaseCam):
 
     @property
     def _class_string(self):
-        return "{} {}".format(self.__class__.__name__, self.resolution)
+        return "{} {} at {} frames per second".format(self.__class__.__name__, self.resolution, self.framerate)

--- a/mule/parts/display.py
+++ b/mule/parts/display.py
@@ -1,8 +1,9 @@
 from parts.base import BasePart
 import cv2
+import parts.base
 
 
-class DisplayFeed(BasePart):
+class DisplayFeed(BasePart,parts.base.PartIntrospect):
     ''' Displays image feed to screen '''
     input_keys = ('camera_array', )
     output_keys = ()

--- a/mule/parts/display.py
+++ b/mule/parts/display.py
@@ -3,7 +3,7 @@ import cv2
 import parts.base
 
 
-class DisplayFeed(BasePart,parts.base.PartIntrospect):
+class DisplayFeed(BasePart):
     ''' Displays image feed to screen '''
     input_keys = ('camera_array', )
     output_keys = ()

--- a/mule/parts/joystick.py
+++ b/mule/parts/joystick.py
@@ -243,6 +243,9 @@ class JoystickDevice:
             self._buttons.append(button_name)
 
 
+    @property
+    def _class_string(self):
+        return "{} at {}".format(self.__class__.__name__, self.device_name)
 
 
 # TODO: MJ - {'steering':'human','throttle':'human','recording':False}  


### PR DESCRIPTION
Implement #17 
BasePart now implements default string printing methods for all Part classes

```python
    def __str__(self):
        return "{} with {} and {} input/output keys".format(self._class_string, self.__class__.input_keys, self.__class__.input_keys)

    def __repr__(self):
        return "{} with {} and {} input/output keys".format(self.__class__.__name__, self.__class__.input_keys, self.__class__.input_keys)
    
    
    @property
    def _class_string(self):
        return self.__class__.__name__
```

The `_class_string()` method can/should be overridden where needed to provide useful information i.e. providing the user with the camera resolution to help understand the vehicle build;
```python
    @property
    def _class_string(self):
        return "{} {} at {} frames per second".format(self.__class__.__name__, self.resolution, self.framerate)
```
for the camera parts. 