### PR TITLE
Feature/fine tuning ps3

### DIFF
--- a/mule/configurations/config.Emily.yml
+++ b/mule/configurations/config.Emily.yml
@@ -1,12 +1,12 @@
 drive:
-    freq_hertz: 2
+    freq_hertz: 20
 
 parts:
  - joystick:
       type: PS3Controller
       arguments:
-        scale_throttle_forward: 1.0,
-        scale_throttle_back: 1.0
+        scale_throttle_forward: 0.50
+        scale_throttle_back: 1.5
         scale_steer_left: 1.0
         scale_steer_right: 1.0
  - led: 
@@ -31,7 +31,7 @@ parts:
         arguments:
           controller_select: PCA
           channel: 1
-          full_left_pulse:    425
+          full_left_pulse:    420
           full_right_pulse:   295
  - camera: 
         type: PiCam

--- a/mule/configurations/config.testingps3.yml
+++ b/mule/configurations/config.testingps3.yml
@@ -9,15 +9,6 @@ parts:
         scale_throttle_back: 1.0
         scale_steer_left: 1.0
         scale_steer_right: 1.0
- - led: 
-      type: setup_GPIO
- - led: 
-      type: sequential_LED_loop
-      arguments:
-        PIN_BLUE1: 26
-        PIN_BLUE2: 19
-        PIN_BLUE3: 13
-        PIN_BLUE4: 6
  - actuator:
         type: ThrottleController
         arguments:
@@ -32,15 +23,4 @@ parts:
           controller_select: PCA
           channel: 1
           full_left_pulse:    425
-          full_right_pulse:   295
- - camera: 
-        type: PiCam
- - datastore:
-        type: WriteStore
-        arguments:
-            path: ~/mule_out
-            flg_zip: 1
- - led: 
-      type: record_LED
-      arguments: 
-        PIN_RED: 16            
+          full_right_pulse:   295         

--- a/mule/configurations/config.testingps3.yml
+++ b/mule/configurations/config.testingps3.yml
@@ -5,7 +5,7 @@ parts:
  - joystick:
       type: PS3Controller
       arguments:
-        scale_throttle_forward: 1.0,
+        scale_throttle_forward: 1.0
         scale_throttle_back: 1.0
         scale_steer_left: 1.0
         scale_steer_right: 1.0

--- a/mule/parts/actuator.py
+++ b/mule/parts/actuator.py
@@ -143,7 +143,7 @@ class SteeringController(BasePart):
 
     def transform(self, state):
         ''' Send signal as pulse to servo '''
-        print(state['steering_signal'])
+        #print(state['steering_signal'])
         pulse = self._steering_signal2pulse(state['steering_signal'])
         
         #print("SteeringController.transform() pulse:", pulse)

--- a/mule/parts/actuator.py
+++ b/mule/parts/actuator.py
@@ -143,6 +143,7 @@ class SteeringController(BasePart):
 
     def transform(self, state):
         ''' Send signal as pulse to servo '''
+        print(state['steering_signal'])
         pulse = self._steering_signal2pulse(state['steering_signal'])
         
         #print("SteeringController.transform() pulse:", pulse)


### PR DESCRIPTION
New behavior for live fine tuning! 

DPad left/right switches adjustment modes (throttle fwd, throttle back, steering left, steering right)
DPad up/down adjusts the number
Each mode has a value and a shift amount independently applied
Can add more adjustments by adding new dict entries
ONLY Throttle implemented so far

close #45 